### PR TITLE
Change Dependabot directory for npm and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # JavaScript/Expo app (npm) in repository root
+  # JavaScript/Expo app (npm) in `test-fresh/src/` folder
   - package-ecosystem: "npm"
     directory: "/test-fresh/"
     schedule:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to target the "/test-fresh/" directory for npm package updates.
  * Aligned GitHub Actions dependency checks to the same "/test-fresh/" directory, keeping schedules and limits unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->