### PR TITLE
fix(modals): add missing useTheme import in AddInteractionModal

### DIFF
--- a/test-fresh/src/components/AddInteractionModal.js
+++ b/test-fresh/src/components/AddInteractionModal.js
@@ -7,6 +7,7 @@ import {
   IconButton,
   Chip,
   Menu,
+  useTheme,
 } from 'react-native-paper';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { useTranslation } from 'react-i18next';
@@ -49,6 +50,7 @@ function AddInteractionModal({
   editingInteraction,
 }) {
   const { t } = useTranslation();
+  const theme = useTheme();
   const isEditMode = !!editingInteraction;
 
   const [title, setTitle] = useState('');


### PR DESCRIPTION
- Import useTheme hook from react-native-paper
- Call useTheme() to get theme object
- Fixes ReferenceError: Property 'theme' doesn't exist
- Required for DateTimePicker themeVariant prop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme support for the interaction modal component to ensure it consistently reflects the application's current theme preference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->